### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Release new docs
 
+permissions:
+  contents: read
+
 on:
   push:
     tags: [v*]
@@ -42,6 +45,8 @@ jobs:
     name: Update Docker Compose, Create Manifest, and Deploy
     runs-on: ubuntu-24.04
     needs: build-and-push
+    permissions:
+      contents: write
     steps:
       - name: Checkout Stacks Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/coingaming/moon-react/security/code-scanning/2](https://github.com/coingaming/moon-react/security/code-scanning/2)

To fix this problem, you should explicitly set the `permissions` key in the workflow, either at the root (applying to all jobs) or at the job level (applying to the specific job). The recommended approach for least privilege is to set the minimal permissions the jobs need to function. In this workflow, both jobs use `actions/checkout` (which typically requires `contents: read`) but the deployment job commits and pushes changes, which requires `contents: write` for that job only. Therefore:

- At the root level, set `permissions: contents: read` so all jobs start with least privilege.
- On the `deployment` job, override with its own `permissions:` block: `contents: write` (which enables committing/pushing changes).
This approach ensures as many jobs as possible run with read-only access, except for the one which requires extra privileges.

Required changes:
- Add a `permissions:` block at the root, between lines 2 and 3, with `contents: read`.
- Add a `permissions:` block under the `deployment` job (after `needs:`) with `contents: write`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
