### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,4 +1,6 @@
 name: "Chromatic"
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/coingaming/moon-react/security/code-scanning/1](https://github.com/coingaming/moon-react/security/code-scanning/1)

The appropriate fix is to add a `permissions` block specifying the minimal required permission set, either at the workflow root (top-level) or at the job level. Since the CodeQL alert is at the job definition (`name: Run Chromatic`), and unless individual jobs require different permissions, adding `permissions: contents: read` at the workflow root is best. This ensures all jobs receive the least-privilege permission set by default. If in the future, any job needs extra permissions, they can be elevated explicitly and locally. The change should be made immediately after the `name:` and before the `on:` block to apply to the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
